### PR TITLE
Mp sm create new shopping list

### DIFF
--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -127,6 +127,9 @@ export async function createList(userId, userEmail, listName) {
 	updateDoc(userDocumentRef, {
 		sharedLists: arrayUnion(listDocRef),
 	});
+
+	//added return
+	return listDocRef.path;
 }
 
 /**

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -128,7 +128,6 @@ export async function createList(userId, userEmail, listName) {
 		sharedLists: arrayUnion(listDocRef),
 	});
 
-	//added return
 	return listDocRef.path;
 }
 

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -1,6 +1,36 @@
 import './Home.css';
 import { SingleList } from '../components';
+import { useState } from 'react';
+import { createList, useAuth } from '../api';
+// import { useNavigate } from "react-router-dom";
+// import { useStateWithStorage } from './utils';
+
 export function Home({ data, setListPath }) {
+	const [listName, setListName] = useState('');
+	const [error, setError] = useState('');
+	const { user } = useAuth();
+	const userId = user?.uid;
+	const userEmail = user?.email;
+	// const navigate = useNavigate();
+
+	async function handleSubmit(e) {
+		e.preventDefault();
+
+		try {
+			await createList(userId, userEmail, listName);
+			// console.log(createList(userId, userEmail, listName))
+			//setListPath(pathName)
+			/* need to pass in the new list path into setListPath, and then it should save to localStorage */
+			//save to local storage
+			setListName('');
+			setError('List saved to database');
+			// navigate("/list")
+		} catch (error) {
+			setListName('')(setError('List Not saved to database'));
+			console.log(error);
+		}
+	}
+
 	return (
 		<div className="Home">
 			<p>
@@ -10,15 +40,28 @@ export function Home({ data, setListPath }) {
 				{data &&
 					data.map((list) => {
 						return (
-							<SingleList
-								key={crypto.randomUUID()}
-								name={list.name}
-								setListPath={setListPath}
-								path={list.path}
-							/>
+							<>
+								<SingleList
+									key={crypto.randomUUID()}
+									name={list.name}
+									setListPath={setListPath}
+									path={list.path}
+								/>
+							</>
 						);
 					})}
 			</ul>
+			<form action="" onSubmit={handleSubmit}>
+				<label htmlFor="listName">Enter List Name:</label>
+				<input
+					type="text"
+					id="listName"
+					value={listName}
+					onChange={(e) => setListName(e.target.value)}
+				/>
+				<button>Submit</button>
+				<p>{error}</p>
+			</form>
 		</div>
 	);
 }

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -21,10 +21,13 @@ export function Home({ data, setListPath }) {
 			}
 			const result = await createList(userId, userEmail, listName);
 			setListPath(result);
-			setError('List saved to database');
 			navigate('/list');
-		} catch (error) {
-			setError(error.message);
+
+			setTimeout(() => {
+				alert('List saved to database');
+			}, 100);
+		} catch (err) {
+			setError(err.message);
 			console.log(error);
 		}
 	}

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -16,12 +16,15 @@ export function Home({ data, setListPath }) {
 		e.preventDefault();
 
 		try {
+			if (!listName || !listName.trim()) {
+				throw new Error('Empty field, please enter a valid name');
+			}
 			const result = await createList(userId, userEmail, listName);
 			setListPath(result);
 			setError('List saved to database');
 			navigate('/list');
 		} catch (error) {
-			setError('List Not saved to database');
+			setError(error.message);
 			console.log(error);
 		}
 	}

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -16,11 +16,7 @@ export function Home({ data, setListPath }) {
 		e.preventDefault();
 
 		try {
-			//clean up and refactor code before submitting pull request
-			//i noticed we are getting the same ID for everylist I create so that seems like an issue
-			console.log('Before calling createList');
 			const result = await createList(userId, userEmail, listName);
-			console.log('After calling createList, result:', result);
 			setListPath(result);
 			setError('List saved to database');
 			navigate('/list');

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -2,8 +2,7 @@ import './Home.css';
 import { SingleList } from '../components';
 import { useState } from 'react';
 import { createList, useAuth } from '../api';
-// import { useNavigate } from "react-router-dom";
-// import { useStateWithStorage } from './utils';
+import { useNavigate } from 'react-router-dom';
 
 export function Home({ data, setListPath }) {
 	const [listName, setListName] = useState('');
@@ -11,22 +10,22 @@ export function Home({ data, setListPath }) {
 	const { user } = useAuth();
 	const userId = user?.uid;
 	const userEmail = user?.email;
-	// const navigate = useNavigate();
+	const navigate = useNavigate();
 
 	async function handleSubmit(e) {
 		e.preventDefault();
 
 		try {
-			await createList(userId, userEmail, listName);
-			// console.log(createList(userId, userEmail, listName))
-			//setListPath(pathName)
-			/* need to pass in the new list path into setListPath, and then it should save to localStorage */
-			//save to local storage
-			setListName('');
+			//clean up and refactor code before submitting pull request
+			//i noticed we are getting the same ID for everylist I create so that seems like an issue
+			console.log('Before calling createList');
+			const result = await createList(userId, userEmail, listName);
+			console.log('After calling createList, result:', result);
+			setListPath(result);
 			setError('List saved to database');
-			// navigate("/list")
+			navigate('/list');
 		} catch (error) {
-			setListName('')(setError('List Not saved to database'));
+			setError('List Not saved to database');
 			console.log(error);
 		}
 	}

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -1,5 +1,4 @@
-import { Outlet } from 'react-router-dom';
-import { NavLink } from 'react-router-dom';
+import { Outlet, NavLink } from 'react-router-dom';
 
 import './Layout.css';
 import { useAuth, SignInButton, SignOutButton } from '../api';


### PR DESCRIPTION
## Description

- Changed Home.jsx to display a form for users to add new lists. Lists get saved to local storage, and then users get redirected to the list page.
- In firebase.js added a return to the createList function, in order to pass the list path into the setListPath hook. In Home.jsx setListPath function takes path and saves it to database and local storage.
- Got great practice working with local storage, and working our way back to find where the path was and debugging to then add the return in firebase.js
- Layout.jsx - fixed a duplicate import

## Related Issue

- Closes Issue #4 

## Acceptance Criteria

UI-related tasks:
- [x] The `Home` view displays a form that allows users to enter the name of a shopping list and then create a list with that name.
- [x] The input that accepts the name of the item has a semantic `label` element associated with it
- [x] The user can submit this form with both the mouse and the `Enter` key  
- [x]  When the user submits the form, they see a message indicating that the list either was or was not created and saved to the database.

Data-related tasks:
- [x] Clicking the button uses the `createList` function in `src/api/firebase.js` to create a new shopping list for the user.
- [x] The shopping list path is stored in local storage using the `setListPath` function.
- [x] Once the list has been created and saved, the user is redirected to the `List` view.


## Type of Changes

- Bug fix
- New feature

## Updates
- Added a return to the createList function in firebase.js in order to pass it into the setListPath hook.
- Fixed a bug from Issue #3 that wasn't merged yet. Removed duplicate Navlink import. 

## Testing Steps / QA Criteria

- Log in, add a list name into form, click submit/press Enter
- Should add to local storage, and will redirect to the List page
- Testing Error: In Home.jsx at the handleSubmit function, Add "throw new Error" to check error message
