### PR TITLE
Eb ar estimate next purchase date issue 11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 				"@emotion/react": "^11.13.3",
 				"@emotion/styled": "^11.13.0",
 				"@mui/material": "^6.0.2",
+				"@the-collab-lab/shopping-list-utils": "^2.2.0",
 				"firebase": "^10.12.5",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
@@ -2097,8 +2098,7 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
 			"integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
-
-    },
+		},
 		"node_modules/@esbuild/aix-ppc64": {
 			"version": "0.21.5",
 			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
@@ -4221,6 +4221,15 @@
 			},
 			"peerDependencies": {
 				"@testing-library/dom": ">=7.21.4"
+			}
+		},
+		"node_modules/@the-collab-lab/shopping-list-utils": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@the-collab-lab/shopping-list-utils/-/shopping-list-utils-2.2.0.tgz",
+			"integrity": "sha512-nEN1z/SEOIWO+8JWIgPDNUkrXmXqNomSh5aiZDNdiaUH/JYqyNeXmEOldtMqAfLicSRiFkapcAIlrUUnPzNaog==",
+			"peerDependencies": {
+				"react": "^18.2.0",
+				"react-dom": "^18.2.0"
 			}
 		},
 		"node_modules/@types/aria-query": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"@emotion/react": "^11.13.3",
 		"@emotion/styled": "^11.13.0",
 		"@mui/material": "^6.0.2",
+		"@the-collab-lab/shopping-list-utils": "^2.2.0",
 		"firebase": "^10.12.5",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -100,7 +100,7 @@ export async function addUserToDatabase(user) {
 		return;
 	} else {
 		// If the user doesn't exist, add them to the database.
-		// We'll use the user's email as the document id
+		// We'll use the user's emailƒ as the document id
 		// because it's more likely that the user will know their email
 		// than their uid.
 		await setDoc(doc(db, 'users', user.email), {
@@ -185,10 +185,9 @@ export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
 	});
 }
 
-export async function updateItem(
-	listPath,
-	{ item, totalPurchases, dateCreated, dateLastPurchased, dateNextPurchased },
-) {
+export async function updateItem(listPath, itemId, item) {
+	const { totalPurchases, dateCreated, dateLastPurchased, dateNextPurchased } =
+		item;
 	if (!listPath || listPath.trim() === '') {
 		console.error('Error: Invalid listPath');
 		return;
@@ -200,7 +199,10 @@ export async function updateItem(
 		dateLastPurchased || dateCreated
 	).toDate();
 
-	console.log(dateCreatedOrDateLastPurchased);
+	console.log(
+		'dateCreatedOrDateLastPurchased:',
+		dateCreatedOrDateLastPurchased,
+	);
 
 	const previousEstimate = getDaysBetweenDates(
 		dateCreatedOrDateLastPurchased,
@@ -218,12 +220,12 @@ export async function updateItem(
 		totalPurchases,
 	);
 
-	console.log(daysUntilNextPurchase);
+	console.log('daysUntilNextPurchase:', daysUntilNextPurchase);
 
 	const updateItemListCollectionRef = collection(db, listPath, 'items');
-	const updateItemListDocRef = doc(updateItemListCollectionRef, item);
+	const updateItemListDocRef = doc(updateItemListCollectionRef, itemId);
 	const updateData = {
-		dateLastPurchased: dateLastPurchased,
+		dateLastPurchased: dateLastPurchased || new Date(),
 		dateNextPurchased: daysUntilNextPurchase,
 		totalPurchases: increment(1),
 	};

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -10,7 +10,8 @@ import {
 } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
 import { db } from './config';
-import { getFutureDate, getDaysBetweenDates } from '../utils';
+import { getFutureDate } from '../utils';
+import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 
 /**
  * A custom hook that subscribes to the user's shopping lists in our Firestore
@@ -184,18 +185,41 @@ export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
 	});
 }
 
-export async function updateItem(listPath, { itemName }) {
+export async function updateItem(
+	listPath,
+	{
+		itemName,
+		totalPurchases,
+		getDaysBetweenDates,
+		getFutureDate,
+		daysUntilNextPurchase,
+	},
+) {
 	if (!listPath || listPath.trim() === '') {
 		console.error('Error: Invalid listPath');
 		return;
 	}
+
+	const calculatedNextPurchasedDate = typeof calculateEstimate(
+		daysUntilNextPurchase,
+		getFutureDate,
+		totalPurchases,
+	);
+
+	console.log(calculatedNextPurchasedDate);
+
 	const updateItemListCollectionRef = collection(db, listPath, 'items');
 	const updateItemListDocRef = doc(updateItemListCollectionRef, itemName);
 	const updateData = {
 		dateLastPurchased: new Date(),
-		dateNextPurchased: calculateEstimate(),
+		dateNextPurchased: calculateEstimate(
+			daysUntilNextPurchase,
+			getFutureDate,
+			totalPurchases,
+		),
 		totalPurchases: increment(1),
 	};
+
 	return updateDoc(updateItemListDocRef, updateData);
 }
 

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -194,15 +194,9 @@ export async function updateItem(listPath, itemId, item) {
 	}
 
 	const currentDate = new Date();
-
 	const dateCreatedOrDateLastPurchased = (
 		dateLastPurchased || dateCreated
 	).toDate();
-
-	console.log(
-		'dateCreatedOrDateLastPurchased:',
-		dateCreatedOrDateLastPurchased,
-	);
 
 	const previousEstimate = getDaysBetweenDates(
 		dateCreatedOrDateLastPurchased,
@@ -214,19 +208,27 @@ export async function updateItem(listPath, itemId, item) {
 		dateCreatedOrDateLastPurchased,
 	);
 
+	function addDays(date, days) {
+		const dateToStart = new Date(date);
+		dateToStart.setDate(dateToStart.getDate() + days);
+		return dateToStart.toISOString();
+	}
+
 	const daysUntilNextPurchase = calculateEstimate(
 		previousEstimate,
 		daysSinceLastPurchased,
 		totalPurchases,
 	);
 
-	console.log('daysUntilNextPurchase:', daysUntilNextPurchase);
+	const dateNextPurchasedCalculation = new Date(
+		addDays(dateCreatedOrDateLastPurchased, daysUntilNextPurchase),
+	);
 
 	const updateItemListCollectionRef = collection(db, listPath, 'items');
 	const updateItemListDocRef = doc(updateItemListCollectionRef, itemId);
 	const updateData = {
 		dateLastPurchased: dateLastPurchased || new Date(),
-		dateNextPurchased: daysUntilNextPurchase,
+		dateNextPurchased: dateNextPurchasedCalculation,
 		totalPurchases: increment(1),
 	};
 

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -10,7 +10,7 @@ import {
 } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
 import { db } from './config';
-import { getFutureDate } from '../utils';
+import { getFutureDate, getDaysBetweenDates } from '../utils';
 
 /**
  * A custom hook that subscribes to the user's shopping lists in our Firestore
@@ -193,6 +193,7 @@ export async function updateItem(listPath, { itemName }) {
 	const updateItemListDocRef = doc(updateItemListCollectionRef, itemName);
 	const updateData = {
 		dateLastPurchased: new Date(),
+		dateNextPurchased: calculateEstimate(),
 		totalPurchases: increment(1),
 	};
 	return updateDoc(updateItemListDocRef, updateData);

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -6,7 +6,7 @@ import { increment } from 'firebase/firestore';
 // import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 
 export function ListItem({ item }) {
-	const { name, dateLastPurchased } = item;
+	const { name, dateLastPurchased, dateCreated } = item;
 	const [checked, setChecked] = useState(false);
 	const has24HoursPassed = (dateLastPurchased) => {
 		const purchaseDate = dateLastPurchased.toDate();
@@ -31,18 +31,12 @@ export function ListItem({ item }) {
 		if (!checked) {
 			setChecked(!checked);
 			const listPath = localStorage.getItem('tcl-shopping-list-path');
-			updateItem(listPath, {
-				itemName: name,
-				dateLastPurchased: checked ? new Date() : null,
-				// dateNextPurchased: new Date(),
-				totalPurchases: increment(1),
-			})
+			updateItem(listPath, item)
 				.then(() => {
 					console.log('Item updated successfully.');
 				})
-				.catch(() => {
+				.catch((error) => {
 					console.error('Error updating item: ', error);
-					console.log(error);
 				});
 		}
 	};

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -8,16 +8,20 @@ import { increment } from 'firebase/firestore';
 export function ListItem({ item }) {
 	const { name, dateLastPurchased, dateCreated, id } = item;
 	const [checked, setChecked] = useState(false);
+
 	const has24HoursPassed = (dateLastPurchased) => {
-		const purchaseDate = dateLastPurchased.toDate();
+		const purchaseDate = new Date(dateLastPurchased);
 		const currentTime = new Date().getTime(); // Current time in milliseconds
 		const ONE_DAY_IN_MILLISECONDS = 86400000; // 24 hours in milliseconds
 		return currentTime - purchaseDate >= ONE_DAY_IN_MILLISECONDS;
 	};
 	// console.log(calculateEstimate);
 
+	console.log('dateCreated: ', item.dateCreated.toDate());
+
 	useEffect(() => {
 		if (dateLastPurchased) {
+			setChecked(has24HoursPassed(dateLastPurchased));
 			const is24HoursPassed = has24HoursPassed(dateLastPurchased);
 			if (is24HoursPassed) {
 				setChecked(false);
@@ -37,8 +41,6 @@ export function ListItem({ item }) {
 				console.error('Error: List path is not set in localStorage.');
 				return; // Exit if listPath is invalid
 			}
-
-			console.log('listPath:', listPath, 'item:', item);
 
 			updateItem(listPath, id, item)
 				.then(() => {

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -6,7 +6,7 @@ import { increment } from 'firebase/firestore';
 // import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 
 export function ListItem({ item }) {
-	const { name, dateLastPurchased, dateCreated } = item;
+	const { name, dateLastPurchased, dateCreated, id } = item;
 	const [checked, setChecked] = useState(false);
 	const has24HoursPassed = (dateLastPurchased) => {
 		const purchaseDate = dateLastPurchased.toDate();
@@ -31,7 +31,16 @@ export function ListItem({ item }) {
 		if (!checked) {
 			setChecked(!checked);
 			const listPath = localStorage.getItem('tcl-shopping-list-path');
-			updateItem(listPath, item)
+
+			//to delete
+			if (!listPath) {
+				console.error('Error: List path is not set in localStorage.');
+				return; // Exit if listPath is invalid
+			}
+
+			console.log('listPath:', listPath, 'item:', item);
+
+			updateItem(listPath, id, item)
 				.then(() => {
 					console.log('Item updated successfully.');
 				})

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -2,6 +2,8 @@ import { useState, useEffect } from 'react';
 import './ListItem.css';
 import { updateItem } from '../api';
 import { increment } from 'firebase/firestore';
+// import { getDaysBetweenDates } from '../utils/dates';
+// import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 
 export function ListItem({ item }) {
 	const { name, dateLastPurchased } = item;
@@ -12,6 +14,7 @@ export function ListItem({ item }) {
 		const ONE_DAY_IN_MILLISECONDS = 86400000; // 24 hours in milliseconds
 		return currentTime - purchaseDate >= ONE_DAY_IN_MILLISECONDS;
 	};
+	// console.log(calculateEstimate);
 
 	useEffect(() => {
 		if (dateLastPurchased) {
@@ -31,6 +34,7 @@ export function ListItem({ item }) {
 			updateItem(listPath, {
 				itemName: name,
 				dateLastPurchased: checked ? new Date() : null,
+				// dateNextPurchased: new Date(),
 				totalPurchases: increment(1),
 			})
 				.then(() => {
@@ -38,6 +42,7 @@ export function ListItem({ item }) {
 				})
 				.catch(() => {
 					console.error('Error updating item: ', error);
+					console.log(error);
 				});
 		}
 	};

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -8,5 +8,33 @@ const ONE_DAY_IN_MILLISECONDS = 86400000;
  * @param {number} offset
  */
 export function getFutureDate(offset) {
+	if (dateLastPurchased === null) {
+		getFutureDate + createdDate;
+	} else {
+		getFutureDate + dateLastPurchased;
+	}
+
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
+}
+
+export function getDaysBetweenDates(dateNextPurchased) {
+	const dateNextPurchasedNumber = dateNextPurchased.getTime();
+	const currentDay = Date.now();
+	return Math.ceil(
+		(dateNextPurchasedNumber - currentDay) / ONE_DAY_IN_MILLISECONDS,
+	);
+}
+
+// getDaysBetweenDates: We need to write a function that calculates current day - dateLastPurchased to calculate the number of days between the current day and the date last purchased
+// if dateLastPurchased = null, then dateNextPurchased = null
+// dateNextPurchased = days until you need this item again + dateLastPurchased
+
+// I think we need to get an item's dateLastPurchased from firebase
+// How do we access that? Import from firebase.js?
+// getDaysBetweenDates should be return integer
+
+if (dateLastPurchased === null) {
+	getFutureDate + createdDate;
+} else {
+	getFutureDate + dateLastPurchased;
 }

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -1,3 +1,5 @@
+// import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
+
 const ONE_DAY_IN_MILLISECONDS = 86400000;
 
 /**
@@ -8,21 +10,15 @@ const ONE_DAY_IN_MILLISECONDS = 86400000;
  * @param {number} offset
  */
 export function getFutureDate(offset) {
-	if (dateLastPurchased === null) {
-		getFutureDate + createdDate;
-	} else {
-		getFutureDate + dateLastPurchased;
-	}
+	console.log(new Date(Date.now() + offset * 86400000));
 
-	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
+	return new Date(Date.now() + offset * 86400000);
 }
 
-export function getDaysBetweenDates(dateNextPurchased) {
-	const dateNextPurchasedNumber = dateNextPurchased.getTime();
+export function getDaysBetweenDates(dateLastPurchased) {
+	const dateLastPurchasedNumber = dateLastPurchased.getTime();
 	const currentDay = Date.now();
-	return Math.ceil(
-		(dateNextPurchasedNumber - currentDay) / ONE_DAY_IN_MILLISECONDS,
-	);
+	return Math.ceil((currentDay - dateLastPurchasedNumber) / 86400000);
 }
 
 // getDaysBetweenDates: We need to write a function that calculates current day - dateLastPurchased to calculate the number of days between the current day and the date last purchased
@@ -33,8 +29,8 @@ export function getDaysBetweenDates(dateNextPurchased) {
 // How do we access that? Import from firebase.js?
 // getDaysBetweenDates should be return integer
 
-if (dateLastPurchased === null) {
-	getFutureDate + createdDate;
-} else {
-	getFutureDate + dateLastPurchased;
-}
+// if (dateLastPurchased === null) {
+// 	getFutureDate + createdDate;
+// } else {
+// 	getFutureDate + dateLastPurchased;
+// }

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -10,15 +10,18 @@ const ONE_DAY_IN_MILLISECONDS = 86400000;
  * @param {number} offset
  */
 export function getFutureDate(offset) {
-	console.log(new Date(Date.now() + offset * 86400000));
+	console.log(new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS));
 
-	return new Date(Date.now() + offset * 86400000);
+	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
 
-export function getDaysBetweenDates(dateLastPurchased) {
-	const dateLastPurchasedNumber = dateLastPurchased.getTime();
-	const currentDay = Date.now();
-	return Math.ceil((currentDay - dateLastPurchasedNumber) / 86400000);
+export function getDaysBetweenDates(startDate, endDate) {
+	const startDateInNumber = startDate.getTime();
+	const endDateInNumber = endDate.getTime();
+
+	return Math.ceil(
+		(startDateInNumber - endDateInNumber) / ONE_DAY_IN_MILLISECONDS,
+	);
 }
 
 // getDaysBetweenDates: We need to write a function that calculates current day - dateLastPurchased to calculate the number of days between the current day and the date last purchased


### PR DESCRIPTION
## Description

- When a user checks a checkbox, Firebase updates with a new date in the `dateNextPurchased` field
- `dateNextPurchased` uses the `calculateEstimate` function that takes into consideration three arguments: `previousEstimate`, `daysSinceLastPurchase`, and `totalPurchases` to give the user a more tailored dateNextPurchased estimate.

## Related Issue

closes 11

## Acceptance Criteria

- [X] When the user purchases an item, the item’s dateNextPurchased property is calculated using the calculateEstimate function and saved to the Firestore database
- [X]  dateNextPurchased is saved as a date, not a number
- [X]  A getDaysBetweenDates function is exported from utils/dates.js and imported into api/firebase.js
- [X]  This function takes two JavaScript Dates and return the number of days that have passed between them

## Type of Changes

`enhancement`

## Updates

### Before
<img width="1399" alt="Screen Shot 2024-09-14 at 11 43 59 PM" src="https://github.com/user-attachments/assets/e39a5b55-6200-49d4-9a44-af86505aac71">
<img width="1410" alt="Screen Shot 2024-09-14 at 11 44 17 PM" src="https://github.com/user-attachments/assets/22eec685-311d-451a-b117-7601942926db">

- When user adds grapefruit to their list, `dateNextPurchased` is populated with a date that is days selected when adding an item (soon, kind of soon, not soon). 
- Example: grapefruit is added on September 14, and dateNextPurchased is set to September 28


### After
<img width="1399" alt="Screen Shot 2024-09-14 at 11 45 35 PM" src="https://github.com/user-attachments/assets/b3d6e28d-ce91-4196-9bc2-dee0e03da690">

- When user adds lemons to their list, `dateNextPurchased` is populated with a date that calculates the user's shopping habits. If the user adds the item and checks it off immediately, `dateNextPurchased` takes into account the user buying the item once and one day later, and how often the user purchases the item.

## Testing Steps / QA Criteria

- Pull from `eb-ar-estimate-next-purchase-date-issue-11` branch
- Add an item and check the `dateNextPurchase` and `dateLastPurchase`
- Check that item off the list and see the `dateNextPurchase` will be to the next day.

## **Current bugs and blockers:**
- Checkbox does not stay checked when user attempts to check and item off their list.
- `dateNextPurchased` does not update when manually testing `dateLastPurchase` and `dateCreated`.
