### PR TITLE
View item details

### DIFF
--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -6,9 +6,8 @@ export function ListItem({ item }) {
 	const { name, dateLastPurchased, dateNextPurchased, totalPurchases, id } =
 		item;
 	const [checked, setChecked] = useState(false);
+	const [isActive, setIsActive] = useState(false);
 
-	const dateNext = new Date(dateNextPurchased?.toDate());
-	const dateLast = dateLastPurchased?.toDate();
 	const handleDelete = async () => {
 		try {
 			if (window.confirm(`Are you sure you want to delete ${name}?`)) {
@@ -63,14 +62,22 @@ export function ListItem({ item }) {
 			<h2>{name}</h2>
 
 			<button onClick={handleDelete}>Delete</button>
-			<div>
+			<button onClick={() => setIsActive(!isActive)}>
+				View Purchase Details
+			</button>
+
+			<div style={{ display: isActive ? 'block' : 'none' }}>
 				<ul>
 					<li>
 						Last Purchased:
 						{dateLastPurchased?.toDate().toDateString()}
 					</li>
-					<li> Next Purchased:{dateNextPurchased?.toDate().toDateString()}</li>
-					<li>Total Purchases:{totalPurchases}</li>
+					<li>
+						{' '}
+						Next Purchased:
+						{dateNextPurchased?.toDate().toDateString()}
+					</li>
+					<li>Total Purchases: {totalPurchases}</li>
 				</ul>
 			</div>
 		</li>

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -59,7 +59,7 @@ export function ListItem({ item }) {
 				onChange={handleChange}
 				disabled={checked}
 			/>
-			<h2>{name}</h2>
+			<h2 style={{ fontSize: '20px' }}>{name}</h2>
 
 			<button onClick={handleDelete}>Delete</button>
 			<button onClick={() => setIsActive(!isActive)}>
@@ -67,16 +67,19 @@ export function ListItem({ item }) {
 			</button>
 
 			<div style={{ display: isActive ? 'block' : 'none' }}>
-				<ul>
+				<ul style={{ fontSize: '15px' }}>
 					<li>
 						Last Purchase:
-						{dateLastPurchased
-							? dateLastPurchased.toDate().toDateString()
-							: 'N/A'}
+						<span>
+							{' '}
+							{dateLastPurchased
+								? dateLastPurchased.toDate().toDateString()
+								: 'N/A'}
+						</span>
 					</li>
 					<li>
 						Next Purchase:
-						{dateNextPurchased?.toDate().toDateString()}
+						<span> {dateNextPurchased?.toDate().toDateString()}</span>
 					</li>
 					<li>Total Purchases: {totalPurchases}</li>
 				</ul>

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -69,12 +69,11 @@ export function ListItem({ item }) {
 			<div style={{ display: isActive ? 'block' : 'none' }}>
 				<ul>
 					<li>
-						Last Purchased:
+						Last Purchase:
 						{dateLastPurchased?.toDate().toDateString()}
 					</li>
 					<li>
-						{' '}
-						Next Purchased:
+						Next Purchase:
 						{dateNextPurchased?.toDate().toDateString()}
 					</li>
 					<li>Total Purchases: {totalPurchases}</li>

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -70,7 +70,9 @@ export function ListItem({ item }) {
 				<ul>
 					<li>
 						Last Purchase:
-						{dateLastPurchased?.toDate().toDateString()}
+						{dateLastPurchased
+							? dateLastPurchased.toDate().toDateString()
+							: 'N/A'}
 					</li>
 					<li>
 						Next Purchase:

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -3,9 +3,12 @@ import './ListItem.css';
 import { updateItem, deleteItem } from '../api';
 
 export function ListItem({ item }) {
-	const { name, dateLastPurchased, id } = item;
+	const { name, dateLastPurchased, dateNextPurchased, totalPurchases, id } =
+		item;
 	const [checked, setChecked] = useState(false);
 
+	const dateNext = new Date(dateNextPurchased?.toDate());
+	const dateLast = dateLastPurchased?.toDate();
 	const handleDelete = async () => {
 		try {
 			if (window.confirm(`Are you sure you want to delete ${name}?`)) {
@@ -57,8 +60,19 @@ export function ListItem({ item }) {
 				onChange={handleChange}
 				disabled={checked}
 			/>
-			{name}
+			<h2>{name}</h2>
+
 			<button onClick={handleDelete}>Delete</button>
+			<div>
+				<ul>
+					<li>
+						Last Purchased:
+						{dateLastPurchased?.toDate().toDateString()}
+					</li>
+					<li> Next Purchased:{dateNextPurchased?.toDate().toDateString()}</li>
+					<li>Total Purchases:{totalPurchases}</li>
+				</ul>
+			</div>
 		</li>
 	);
 }


### PR DESCRIPTION
## Description

- In `ListItem` created a div to hold item details
- Passed in `dateNextPurchased` and `totalPurchases` from the `item` object
- displayed the details in a list
- created a toggle button to switch between open and closed states

Ideally, we can use this as a base for more stylistic choices coming up.

## Related Issue

closes #37 (#21)

## Acceptance Criteria

- [x] User has the option to view details on an item from their list
- [x] User can see `dateLastPurchased`, `dateNextPurchase`, and `totalPurchases` pertaining to a single item.
- [x] Data is accurate to the specific item

## Type of Changes

`enhancement`

## Updates

### After
<img width="461" alt="Screenshot 2024-09-24 at 11 51 50 AM" src="https://github.com/user-attachments/assets/e656e8a6-8794-4e37-a175-e82fa8085d54">

<img width="496" alt="Screenshot 2024-09-24 at 11 51 59 AM" src="https://github.com/user-attachments/assets/fe5e79a2-3308-4274-bdfb-db7e504a2a0d">

## Testing Steps / QA Criteria

- View list of items on `List` and there should be a `View Purchase Details` button
- Clicking button will open and should display details
- Open Firebase to list info see if `dateLastPurchased`, `dateNextPurchase`, and `totalPurchases` are the same as whats displayed
- Clicking button should toggle between displaying and hiding the div