### PR TITLE
Ar navbar updates issue 19

### DIFF
--- a/src/api/useAuth.jsx
+++ b/src/api/useAuth.jsx
@@ -21,7 +21,10 @@ export const SignInButton = () => (
  * A button that signs the user out of the app using Firebase Auth.
  */
 export const SignOutButton = () => (
-	<button type="button" onClick={() => auth.signOut()}>
+	<button
+		type="button"
+		onClick={() => auth.signOut() && window.location.reload()}
+	>
 		Sign Out
 	</button>
 );

--- a/src/views/Layout.css
+++ b/src/views/Layout.css
@@ -44,7 +44,7 @@
 	padding-bottom: max(env(safe-area-inset-bottom), 1rem);
 	padding-top: 1rem;
 	place-content: center;
-	position: fixed;
+	/* position: fixed; */
 	width: 100%;
 }
 
@@ -53,6 +53,8 @@
 	flex-direction: row;
 	justify-content: space-evenly;
 	width: min(72ch, 100%);
+	/* position: fixed;
+	top: 0; */
 }
 
 .Nav-link {

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -29,6 +29,8 @@ export function Layout() {
 				</header>
 				<nav className="Nav">
 					<div className="Nav-container">
+						{user ? <SignOutButton /> : <SignInButton />}
+
 						<NavLink to="/" style={handleActive}>
 							Home
 						</NavLink>
@@ -42,8 +44,8 @@ export function Layout() {
 						</NavLink>
 					</div>
 				</nav>
+
 				<main className="Layout-main">
-					{user ? <SignOutButton /> : <SignInButton />}
 					<Outlet />
 				</main>
 			</div>

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -29,8 +29,6 @@ export function Layout() {
 				</header>
 				<nav className="Nav">
 					<div className="Nav-container">
-						{user ? <SignOutButton /> : <SignInButton />}
-
 						<NavLink to="/" style={handleActive}>
 							Home
 						</NavLink>
@@ -42,6 +40,8 @@ export function Layout() {
 						<NavLink to="/manage-list" style={handleActive}>
 							Manage List
 						</NavLink>
+
+						{user ? <SignOutButton /> : <SignInButton />}
 					</div>
 				</nav>
 

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -27,10 +27,6 @@ export function Layout() {
 				<header className="Layout-header">
 					<h1>Smart shopping list</h1>
 				</header>
-				<main className="Layout-main">
-					{user ? <SignOutButton /> : <SignInButton />}
-					<Outlet />
-				</main>
 				<nav className="Nav">
 					<div className="Nav-container">
 						<NavLink to="/" style={handleActive}>
@@ -46,6 +42,10 @@ export function Layout() {
 						</NavLink>
 					</div>
 				</nav>
+				<main className="Layout-main">
+					{user ? <SignOutButton /> : <SignInButton />}
+					<Outlet />
+				</main>
 			</div>
 		</>
 	);


### PR DESCRIPTION
## Description

Moved the navbar to the top of the screen. Added Sign In/Sign Out button to navbar, and added a page refresh when user clicks Sign Out.

## Related Issue
 
closes 19

## Acceptance Criteria

- [X]  Navbar is located at the top of the screen, under the heading
- [X]  The navbar is consistent throughout all pages of the app
- [X]  There is a Sign In option in the navbar: When a user is not signed in, the user can click it, and then they can sign in
- [X]  There is a Sign Out option in the navbar: When a user is signed in, the user can click it, and they they can sign out
- [X]  There is a Home option in the navbar: When a user clicks Home they are taken back to to view all of their lists

## Type of Changes

`enhancement`

## Updates

### Before
<img width="841" alt="Screen Shot 2024-09-30 at 2 04 49 PM" src="https://github.com/user-attachments/assets/52d6a0a1-533b-4f65-9252-c2ba0e1ea261">

### After
<img width="799" alt="Screen Shot 2024-09-30 at 2 04 12 PM" src="https://github.com/user-attachments/assets/7bed09c5-1e82-4ad0-82ff-28afe09d1909">

## Testing Steps / QA Criteria

- Pull from `ar-navbar-updates-issue-19`
- Click Sign In
- Follow sign in instructions
- Sign Out