### PR TITLE
Delete from all instances as lists' owner and unfollow shared lists

### DIFF
--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -9,6 +9,9 @@ import {
 	increment,
 	deleteDoc,
 	arrayRemove,
+	query,
+	where,
+	getDocs,
 } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
 import { db } from './config';
@@ -266,6 +269,21 @@ export async function deleteList(userEmail, listPath) {
 		const userDocumentRef = doc(db, 'users', userEmail);
 		await updateDoc(userDocumentRef, {
 			sharedLists: arrayRemove(listDocRef),
+		});
+
+		const usersCollectionRef = collection(db, 'users');
+		const q = query(
+			usersCollectionRef,
+			where('sharedWithMe', 'array-contains', listDocRef),
+		);
+
+		const usersWhoHasList = await getDocs(q);
+
+		usersWhoHasList.forEach(async (docSnapshot) => {
+			const userDocRef = doc(db, 'users', docSnapshot.id);
+			await updateDoc(userDocRef, {
+				sharedWithMe: arrayRemove(listDocRef),
+			});
 		});
 	} catch (error) {
 		console.error('Error deleting the list:', error);

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -272,6 +272,20 @@ export async function deleteList(userEmail, listPath) {
 	}
 }
 
+export async function unfollowList(userEmail, listPath) {
+	try {
+		const listDocRef = doc(db, listPath);
+
+		// Remove the list reference from the user's sharedWithMe array
+		const userDocumentRef = doc(db, 'users', userEmail);
+		await updateDoc(userDocumentRef, {
+			sharedWithMe: arrayRemove(listDocRef),
+		});
+	} catch (error) {
+		console.error('Error unfollowing the list:', error);
+	}
+}
+
 export function comparePurchaseUrgency(list) {
 	const currentDate = new Date();
 	const soon = [];

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { useVoiceToText } from '../utils';
 import DeleteIcon from '@mui/icons-material/Delete';
 import KeyboardVoiceIcon from '@mui/icons-material/KeyboardVoice';
+import RemoveCircleIcon from '@mui/icons-material/RemoveCircle'; //remove shopping list that are being shared with
 
 export function Home({ data, setListPath, setAllLists }) {
 	const [listName, setListName] = useState('');
@@ -57,6 +58,10 @@ export function Home({ data, setListPath, setAllLists }) {
 		}
 	};
 
+	const handleRemoveSharedList = async (list) => {
+		return;
+	};
+
 	return (
 		<div className="flex flex-col h-[80vh]  my-8 p-8 bg-white rounded-3xl shadow-xl overflow-hidden mx-auto">
 			<ul className="font-archivo flex-grow overflow-y-auto space-y-4">
@@ -72,9 +77,24 @@ export function Home({ data, setListPath, setAllLists }) {
 										path={list.path}
 									/>
 									<div className="flex items-center space-x-4">
-										<button onClick={() => handleDelete(list)} className="p-2">
-											<DeleteIcon />
-										</button>
+										{!list.isShared && (
+											<button
+												onClick={() => handleDelete(list)}
+												className="p-2"
+											>
+												<DeleteIcon />
+											</button>
+										)}
+
+										{/* Remove button for shared lists */}
+										{list.isShared && (
+											<button
+												onClick={() => handleRemoveSharedList(list)}
+												className="p-2"
+											>
+												<RemoveCircleIcon />
+											</button>
+										)}
 										<ShareListComponent
 											name={list.name}
 											setListPath={setListPath}

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -1,6 +1,6 @@
 import './Home.css';
 import { SingleList, ShareListComponent } from '../components';
-import { createList, useAuth, deleteList } from '../api';
+import { createList, useAuth, deleteList, unfollowList } from '../api';
 import { Fragment, useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useVoiceToText } from '../utils';
@@ -58,8 +58,23 @@ export function Home({ data, setListPath, setAllLists }) {
 		}
 	};
 
-	const handleRemoveSharedList = async (list) => {
-		return;
+	const handleUnfollowSharedList = async (list) => {
+		try {
+			if (
+				window.confirm(
+					`Are you sure you want to remove ${list.name} from your shopping lists?`,
+				)
+			) {
+				await unfollowList(userEmail, list.path);
+				const updatedData = data.filter(
+					(eachList) => eachList.path !== list.path,
+				);
+
+				setAllLists(updatedData);
+			}
+		} catch (error) {
+			console.log(error);
+		}
 	};
 
 	return (
@@ -89,7 +104,7 @@ export function Home({ data, setListPath, setAllLists }) {
 										{/* Remove button for shared lists */}
 										{list.isShared && (
 											<button
-												onClick={() => handleRemoveSharedList(list)}
+												onClick={() => handleUnfollowSharedList(list)}
 												className="p-2"
 											>
 												<RemoveCircleIcon />


### PR DESCRIPTION
## Description


This PR resolves a bug where, when a list owner deletes a list, it would be removed from all instances, including for users it was shared with. For users who have the list shared with them, they can only unfollow the list—removing it from their sharedWithMe array—but not delete the original list. I also changed the delete icon to a remove icon for shared lists.

## Related Issue

closes #60 

## Acceptance Criteria


- [ ] When a user deletes a list that they have created and shared, the list is gone from all collections
- [ ] When a user deletes a list that they have been shared to, but do not own, the list is removed from their collection, but not every collection that list belongs to. (I.e., the creator of a list is the only user who can permanently delete a list)
## Type of Changes


`bug fix` `enhancement` 
## Updates

### After
![Screenshot 2024-10-12 at 4 52 10 PM](https://github.com/user-attachments/assets/775af36d-9655-4452-a711-5757b9ddbf95)

![Screenshot 2024-10-12 at 4 52 29 PM](https://github.com/user-attachments/assets/51aa12bf-c16c-47dd-b081-616f99e499cc)
![Screenshot 2024-10-12 at 4 53 00 PM](https://github.com/user-attachments/assets/9e83a6c4-5c3c-4ccb-85e9-59cf9a3ec05c)


## Testing Steps / QA Criteria

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->
1. go to `eb-deletion-issue-32`branch.
2. Share some lists with other users and check the updates in Firebase under the 'sharedWithMe' lists.
3. Delete the list shared with other users and confirm that it is removed from the 'sharedWithMe' lists.
